### PR TITLE
pages と editor に関するバグの修正

### DIFF
--- a/jsme.bst
+++ b/jsme.bst
@@ -3144,8 +3144,8 @@ FUNCTION {format.pages}
     { "" }
     { is.kanji.entry
 	{ pages multi.page.check
-	  { bst.pages.pre.jp pages n.dashify convert.num.pages tie.or.space.connect * bst.page.post.jp * }
-	  { bst.page.pre.jp pages convert.num.pages tie.or.space.connect * bst.page.post.jp * }
+	  { bst.pages.pre.jp pages n.dashify convert.num.pages tie.or.space.connect * bst.page.post.jp }
+	  { bst.page.pre.jp pages convert.num.pages tie.or.space.connect * bst.page.post.jp }
 	 if$
 	}
 	{ pages multi.page.check
@@ -4076,6 +4076,7 @@ FUNCTION {proceedings}
     { organization output.nocomma }
     { format.editors output.nonnull.nocomma }
   if$
+  write$
   bst.year.position #0 =
     { format.year "year" output.check.nocomma }
     'skip$


### PR DESCRIPTION
pages を使用している日本語文献でエラーが出ていた．
また，proceedings の editor フィールドを処理する際にスタックを空に
できていない問題が発生していた．
format.pages と proceedings の定義を修正し，対応した．
proceedings の定義に関しては write$ を挿入することで対応したので
根本的な解決にはなっていない可能性がある．